### PR TITLE
Conform to TAP spec - lol

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Options:
                                  artifacts [default=1]
   --compare-masked               Only compare masks + unmasked areas of RGBA
                                  rasters
-  --no-error                     Compare in non stderr mode: echos "(OK|NOT
-                                 OK) - <input_1> is (within|not within)
+  --no-error                     Compare in non stderr mode: echos "(ok|not
+                                 ok) - <input_1> is (within|not within)
                                  <pixel-threshold> pixels of <input 2>"
   --debug                        Print ascii preview of errors
   --flex-mode                    Allow comparison of masked RGB + RGBA

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,8 @@ compare
                                      artifacts [default=1]
       --compare-masked               Only compare masks + unmasked areas of RGBA
                                      rasters
-      --no-error                     Compare in non stderr mode: echos "(OK|NOT
-                                     OK) - <input_1> is (within|not within)
+      --no-error                     Compare in non stderr mode: echos "(ok|not
+                                     ok) - <input_1> is (within|not within)
                                      <pixel-threshold> pixels of <input 2>"
       --debug                        Print ascii preview of errors
       --flex-mode                    Allow comparison of masked RGB + RGBA

--- a/raster_tester/__init__.py
+++ b/raster_tester/__init__.py
@@ -27,7 +27,7 @@ def upsample_array(bidx, up, fr, to):
 
 def exception_raiser(message, no_stderr):
     if no_stderr:
-        click.echo("NOT OK - %s" % (message))
+        click.echo("not ok - %s" % (message))
         sys.exit(0)
     else:
         raise ValueError, message
@@ -144,4 +144,4 @@ def compare(srcpath1, srcpath2, max_px_diff=0, upsample=1, downsample=1, compare
                 if aboveThreshold:
                     exception_raiser('Band %s has %s pixels that vary by more than 16' % (bidx, difference), no_stderr)
 
-    click.echo("OK - %s is similar to within %s pixels of %s" % (srcpath1, max_px_diff, srcpath2))
+    click.echo("ok - %s is similar to within %s pixels of %s" % (srcpath1, max_px_diff, srcpath2))

--- a/raster_tester/scripts/cli.py
+++ b/raster_tester/scripts/cli.py
@@ -18,7 +18,7 @@ def cli():
 @click.option("--compare-masked", is_flag=True,
     help='Only compare masks + unmasked areas of RGBA rasters')
 @click.option("--no-error", is_flag=True,
-    help='Compare in non stderr mode: echos "(OK|NOT OK) - <input_1> is (within|not within) <pixel-threshold> pixels of <input 2>"')
+    help='Compare in non stderr mode: echos "(ok|not ok) - <input_1> is (within|not within) <pixel-threshold> pixels of <input 2>"')
 @click.option("--debug", is_flag=True,
     help='Print ascii preview of errors')
 @click.option("--flex-mode", is_flag=True,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs_open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='raster-tester',
-      version='0.6.0',
+      version='0.6.1',
       description=u"Tools for testing rasters",
       long_description=long_description,
       classifiers=[],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,7 @@ def test_cli_okcompare_bad_no_error():
     runner = CliRunner()
     result = runner.invoke(cli, ['compare', 'tests/expected/blobby.tif', 'tests/fixtures/notblobby.tif', '--upsample', '8', '--downsample', '64', '--no-error'])
     assert result.exit_code == 0
-    assert result.output_bytes == 'NOT OK - Band 1 has 363 pixels that vary by more than 16\n'
+    assert result.output_bytes == 'not ok - Band 1 has 363 pixels that vary by more than 16\n'
 
 def test_cli_okcompare_rgb():
     runner = CliRunner()


### PR DESCRIPTION
Ok, first let me explain myself.

I started trying to get PXM tests passing on Circle, ended up needing to run the tests locally, and noticed that my `npm test | tap-spec` output looked wierd.

![](https://cldup.com/gx9zHJ8Tkd.thumb.png)

So uh, those `OK`'s should be `ok`'s. And this PR... changes the capitalization of 4 characters... Here's... [the spec](https://testanything.org/tap-specification.html)...

:v: 

@dnomadb can I merge this before anyone else sees it?
